### PR TITLE
Fix integration tests

### DIFF
--- a/src/test/java/org/apache/activemq/wildfly/integration/tests/TransactionManagerLocatorTest.java
+++ b/src/test/java/org/apache/activemq/wildfly/integration/tests/TransactionManagerLocatorTest.java
@@ -23,6 +23,7 @@ package org.apache.activemq.wildfly.integration.tests;
 
 import org.apache.activemq.service.extensions.ServiceUtils;
 import org.apache.activemq.wildfly.integration.fake.DummyTransactionManager;
+import org.junit.After;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -41,5 +42,11 @@ public class TransactionManagerLocatorTest extends Assert
        initialContext.bind("java:/TransactionManager", new DummyTransactionManager());
        assertNotNull(ServiceUtils.getTransactionManager());
        assertTrue(ServiceUtils.getTransactionManager() instanceof DummyTransactionManager);
+   }
+
+   @After
+   public void resetTransactionManager()
+   {
+      ServiceUtils.setTransactionManager(null);
    }
 }

--- a/src/test/java/org/apache/activemq/wildfly/integration/tests/recovery/WildFlyRecoveryRegistryTest.java
+++ b/src/test/java/org/apache/activemq/wildfly/integration/tests/recovery/WildFlyRecoveryRegistryTest.java
@@ -24,6 +24,7 @@ import java.util.concurrent.ConcurrentHashMap;
 
 import org.apache.activemq.ra.ActiveMQResourceAdapter;
 import org.apache.activemq.ra.recovery.RecoveryManager;
+import org.apache.activemq.service.extensions.ServiceUtils;
 import org.apache.activemq.service.extensions.xa.recovery.XARecoveryConfig;
 import org.apache.activemq.tests.integration.ra.ActiveMQRAClusteredTestBase;
 import org.apache.activemq.wildfly.integration.fake.DummyTransactionManager;
@@ -35,7 +36,6 @@ import org.junit.Before;
 import org.junit.Test;
 
 import javax.naming.InitialContext;
-import javax.naming.NamingException;
 
 /**
  * @author mtaylor
@@ -43,13 +43,22 @@ import javax.naming.NamingException;
 
 public class WildFlyRecoveryRegistryTest extends ActiveMQRAClusteredTestBase
 {
+   @Override
    @Before
-   public void addTM() throws NamingException
+   public void setUp() throws Exception
    {
-       System.setProperty("java.naming.factory.initial", "org.apache.activemq.wildfly.integration.fake.DummyInitialContext");
-       InitialContext initialContext = new InitialContext();
-       initialContext.bind("java:/TransactionManager", new DummyTransactionManager());
+      System.setProperty("java.naming.factory.initial", "org.apache.activemq.wildfly.integration.fake.DummyInitialContext");
+      InitialContext initialContext = new InitialContext();
+      initialContext.bind("java:/TransactionManager", new DummyTransactionManager());
+      super.setUp();
    }
+
+   @After
+   public void resetTransactionManager()
+   {
+      ServiceUtils.setTransactionManager(null);
+   }
+
    @Test
    public void testWildFlyRecoveryDiscoveryIsProperlyRegistered() throws Exception
    {


### PR DESCRIPTION
Two issues were causing the test suite to fail intermitently firstly the
ServiceUtils class was keeping a cache of the TransactionManager.  If
the TransactionManagerLocatorTest ran first, the TransactionManager was
cached meaning lookup was never called on the
WildFlyTransactionManagerLocator in subsequent tests.

Secondly there were 2 @Before methods declared on the
WildFlyRecoveryRegistry tests.  Once was inherited from
ActiveMQRAClustered.  Depeding on the order of the @before methods (not
enforced by JUnit) the tests may pass or fail (as JNDI entry would or
would not exist before the lookuo).